### PR TITLE
kraft.yaml: Add configuration to use Musl

### DIFF
--- a/kraft.yaml
+++ b/kraft.yaml
@@ -2,7 +2,7 @@
 specification: '0.5'
 name: redis
 unikraft:
-  version: 9bf6e63
+  version: stable
   kconfig:
     - CONFIG_LIBUK9P=y
     - CONFIG_LIB9PFS=y
@@ -21,15 +21,11 @@ targets:
     platform: linuxu
   - architecture: x86_64
     platform: kvm
+  - architecture: arm64
+    platform: kvm
 libraries:
-  pthread-embedded:
+  musl:
     version: stable
-  newlib:
-    version: stable
-    kconfig:
-      - CONFIG_LIBNEWLIBC=y
-      - CONFIG_LIBNEWLIBC_WANT_IO_C99_FORMATS=y
-      - CONFIG_LIBNEWLIBC_LINUX_ERRNO_EXTENSIONS=y
   lwip:
     version: stable
     kconfig:


### PR DESCRIPTION
Add configuration to use Musl instead of newlib and pthread_embedded.