### PR TITLE
Update platform name according to 0.13 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ sudo qemu-system-x86_64 -fsdev local,id=myid,path=$(pwd)/fs0,security_model=none
                         -device virtio-9p-pci,fsdev=myid,mount_tag=fs0,disable-modern=on,disable-legacy=off \
                         -netdev bridge,id=en0,br=virbr0 \
                         -device virtio-net-pci,netdev=en0 \
-                        -kernel "build/app-redis_kvm-x86_64" \
+                        -kernel "build/app-redis_qemu-x86_64" \
                         -append "netdev.ipv4_addr=172.44.0.2 netdev.ipv4_gw_addr=172.44.0.1 netdev.ipv4_subnet_mask=255.255.255.0 -- /redis.conf" \
                         -cpu host \
                         -enable-kvm \

--- a/kraft.yaml
+++ b/kraft.yaml
@@ -21,9 +21,9 @@ targets:
   - architecture: x86_64
     platform: linuxu
   - architecture: x86_64
-    platform: kvm
+    platform: qemu
   - architecture: arm64
-    platform: kvm
+    platform: qemu
 libraries:
   musl:
     version: stable


### PR DESCRIPTION
v0.13 release introduced an image split between QEMU and Firecracker.